### PR TITLE
[BUGFIX] Explode throw exception for non-string

### DIFF
--- a/Classes/Backend/LayoutSetup.php
+++ b/Classes/Backend/LayoutSetup.php
@@ -263,7 +263,11 @@ class LayoutSetup {
 	 */
 	public function getLayoutWizardItems($colPos, $excludeLayouts = array()) {
 		$wizardItems = array();
-		$excludeLayouts = array_flip(explode(',', $excludeLayouts));
+		
+		if (!is_array($excludeLayouts)) {
+			$excludeLayouts = array_flip(explode(',', $excludeLayouts));
+		}
+
 		foreach ($this->layoutSetup as $layoutId => $item) {
 
 			if (((int)$colPos === -1 && $item['top_level_layout']) || isset($excludeLayouts[$item['uid']])) {


### PR DESCRIPTION
The explode function expects strings as parameters. The parameter excludeLayouts is an array. So this leads to an exception.

I used this function in my extension to fetch the existing layout wizard items. I am not sure when this function will get an string as parameter.

If this can be the case, the method should get the exclude layouts as mixed value e.g.