### PR TITLE
[BUGFIX] Keep all CTypes on empty backend layout

### DIFF
--- a/Classes/Backend/ItemsProcFuncs/CTypeList.php
+++ b/Classes/Backend/ItemsProcFuncs/CTypeList.php
@@ -96,7 +96,7 @@ class CTypeList extends AbstractItemsProcFunc {
 			$gridElement = $this->layoutSetup->cacheCurrentParent($gridContainerId, true);
 			$backendLayout = $this->layoutSetup->getLayoutSetup($gridElement['tx_gridelements_backend_layout']);
 		}
-		if (isset($backendLayout)) {
+		if (!empty($backendLayout)) {
 			foreach ($items as $key => $item) {
 				if (!(GeneralUtility::inList($backendLayout['columns'][$column], $item[1]) || GeneralUtility::inList($backendLayout['columns'][$column], '*'))) {
 					unset($items[$key]);


### PR DESCRIPTION
If there is no backend layout, do not remove all valid CTypes.

I'm not sure what the exact reason for this situation is but we have encountered the `CType` field being empty when trying to create a "Header" element in one of our gridelements. This change fixes the issue.