### PR TITLE
Update PageRenderer.php to read explicitADmode from configuration

### DIFF
--- a/Classes/Hooks/PageRenderer.php
+++ b/Classes/Hooks/PageRenderer.php
@@ -180,7 +180,7 @@ class PageRenderer {
 						top.DDtoken = '" . $formprotection->generateToken('editRecord') . "';
 						top.DDpid = '" . (int)GeneralUtility::_GP('id') . "';
 						top.DDclipboardfilled = '" . ($clipBoardHasContent ? $clipBoardHasContent : 'false') . "';
-						top.pasteReferenceAllowed = '" . ($GLOBALS['BE_USER']->checkAuthMode('tt_content', 'CType', 'shortcut', 'explicitAllow') ? 'true' : 'false') . "';
+						top.pasteReferenceAllowed = '" . ($GLOBALS['BE_USER']->checkAuthMode('tt_content', 'CType', 'shortcut', $GLOBALS['TYPO3_CONF_VARS']['BE']['explicitADmode']) ? 'true' : 'false') . "';
 						top.newElementWizard = '" . ($modTSconfig['properties']['disableNewContentElementWizard'] ? 'false' : 'true') . "';
 						top.DDclipboardElId = '" . $intFirstCBEl . "';
 					" . // replace placeholder for detail info on draggables


### PR DESCRIPTION
If explicitADmode is set to explicitAllow it returns true when the right to add a shortcut is added to the users permissions.
In the othercase if explicitADmode is set to explicitDeny it returns true if the shortcut options has not been excluded.
