### PR TITLE
Update ClickMenuOptions to read explicitADmode from configuration

### DIFF
--- a/Classes/Backend/ClickMenuOptions.php
+++ b/Classes/Backend/ClickMenuOptions.php
@@ -65,7 +65,7 @@ class ClickMenuOptions implements SingletonInterface
             $this->setLanguageService($GLOBALS['LANG']);
 
             // add "paste reference after" if user is allowed to use CType shortcut
-            if ($this->getBackendUser()->checkAuthMode('tt_content', 'CType', 'shortcut', 'explicitAllow')) {
+            if ($this->getBackendUser()->checkAuthMode('tt_content', 'CType', 'shortcut', $GLOBALS['TYPO3_CONF_VARS']['BE']['explicitADmode'])) {
                 if ($menuItems['pasteafter']) {
                     unset($menuItems['pasteafter']);
                     $selItem = $backRef->clipObj->getSelectedRecord();


### PR DESCRIPTION
If explicitADmode is set to explicitAllow it returns true when the right to add a shortcut is added to the users permissions.
In the othercase if explicitADmode is set to explicitDeny it returns true if the shortcut options has not been excluded.
