### PR TITLE
[BUGFIX] Fix possible missing flexform options in backend

### DIFF
--- a/Classes/Backend/LayoutSetup.php
+++ b/Classes/Backend/LayoutSetup.php
@@ -472,10 +472,10 @@ class LayoutSetup
         }
 
         if ($overruleRecords === true) {
-            ArrayUtility::mergeRecursiveWithOverrule($gridLayoutRecords, $gridLayoutConfig);
+            ArrayUtility::mergeRecursiveWithOverrule($gridLayoutRecords, $gridLayoutConfig, true, false);
             $this->setLayoutSetup($gridLayoutRecords);
         } else {
-            ArrayUtility::mergeRecursiveWithOverrule($gridLayoutConfig, $gridLayoutRecords);
+            ArrayUtility::mergeRecursiveWithOverrule($gridLayoutConfig, $gridLayoutRecords, true, false);
             $this->setLayoutSetup($gridLayoutConfig);
         }
     }


### PR DESCRIPTION
When using `flexformDS` in typoscript to indicate a flexform, the fields no longer
show up in the backend because `ArrayUtility::mergeRecursiveWithOverrule` nukes them
with any empty values found in the database record. This commit fixes that by
ignoring empty items in the array merge.
