### PR TITLE
[BUGFIX] Changed extRelPath to siteRelPath.

### DIFF
--- a/Classes/Hooks/PageRenderer.php
+++ b/Classes/Hooks/PageRenderer.php
@@ -47,7 +47,7 @@ class PageRenderer implements SingletonInterface
      */
     public function addJSCSS(array $parameters, \TYPO3\CMS\Core\Page\PageRenderer $pageRenderer)
     {
-        $pageRenderer->addCssFile(ExtensionManagementUtility::extRelPath('gridelements') . 'Resources/Public/Backend/Css/Skin/t3skin_override.css');
+        $pageRenderer->addCssFile(ExtensionManagementUtility::siteRelPath('gridelements') . 'Resources/Public/Backend/Css/Skin/t3skin_override.css');
         if (get_class($GLOBALS['SOBE']) === RecordList::class || is_subclass_of($GLOBALS['SOBE'], RecordList::class)) {
             $pageRenderer->loadRequireJsModule('TYPO3/CMS/Gridelements/GridElementsOnReady');
             return;

--- a/Classes/Hooks/PreHeaderRenderHook.php
+++ b/Classes/Hooks/PreHeaderRenderHook.php
@@ -36,6 +36,6 @@ class PreHeaderRenderHook implements SingletonInterface
     {
         /** @var \TYPO3\CMS\Core\Page\PageRenderer $pagerenderer */
         $pagerenderer = $arg['pageRenderer'];
-        $pagerenderer->addCssFile(ExtensionManagementUtility::extRelPath('gridelements') . 'Resources/Public/Backend/Css/Skin/t3skin_override.css');
+        $pagerenderer->addCssFile(ExtensionManagementUtility::siteRelPath('gridelements') . 'Resources/Public/Backend/Css/Skin/t3skin_override.css');
     }
 }


### PR DESCRIPTION
extRelPath is deprecated and will break in TYPO3 v9.
https://typo3.org/api/typo3cms/class_t_y_p_o3_1_1_c_m_s_1_1_core_1_1_utility_1_1_extension_management_utility.html#abbccb6f4701d4e64c398c0b9492d3b7c