### PR TITLE
[BUGFIX] Fix wrong name for context menu javascript

### DIFF
--- a/Classes/ContextMenu/ItemProvider.php
+++ b/Classes/ContextMenu/ItemProvider.php
@@ -92,7 +92,7 @@ class ItemProvider extends RecordProvider
 
         $attributes = $this->getPasteAdditionalAttributes('after');
         $attributes += [
-            'data-callback-module' => 'TYPO3/CMS/Gridelements/ClickMenuActions',
+            'data-callback-module' => 'TYPO3/CMS/Gridelements/ContextMenuActions',
             'data-action-url' => htmlspecialchars(BackendUtility::getModuleUrl('tce_db', $urlParameters))
         ];
         return $attributes;


### PR DESCRIPTION
The wrong naming here breaks the functionality 'paste as reference after' within the context menu when copying a content element and clicking on the icon of another content element for pasting a reference of the copy after the element. The file Resources/Public/JavaScript/ClickMenuActions.js does not exist, I think this is just a logical error. Error can be seen in the browser dev tools as well
`Failed to load resource: the server responded with a status of 404 (Not Found) ClickMenuActions.js `