### PR TITLE
Cast gridelements_container to integer for ReferenceUpdate

### DIFF
--- a/Classes/DataHandler/AbstractDataHandler.php
+++ b/Classes/DataHandler/AbstractDataHandler.php
@@ -243,8 +243,8 @@ abstract class AbstractDataHandler
             if ($translatedElement['tx_gridelements_container'] !== $updateArray['tx_gridelements_container']) {
                 $containerUpdateArray[$translatedElement['tx_gridelements_container']] -= 1;
                 $containerUpdateArray[$updateArray['tx_gridelements_container']] += 1;
-                $this->getTceMain()->updateRefIndex('tt_content', $translatedElement['tx_gridelements_container']);
-                $this->getTceMain()->updateRefIndex('tt_content', $updateArray['tx_gridelements_container']);
+                $this->getTceMain()->updateRefIndex('tt_content', (int)$translatedElement['tx_gridelements_container']);
+                $this->getTceMain()->updateRefIndex('tt_content', (int)$updateArray['tx_gridelements_container']);
             }
         }
         if (!empty($containerUpdateArray)) {


### PR DESCRIPTION
This change prevents strict type conversion null errors in the `ReferenceIndex` the when no
`gridelements_container` is set (and the value would strictly be null).

Error message for reference:
```
Argument 2 passed to TYPO3\CMS\Core\Database\ReferenceIndex::getRecordRawCached() must be of the type integer, null given, called in .../typo3_src-8.7.2/typo3/sysext/core/Classes/Database/ReferenceIndex.php on line 240
```