### PR TITLE
[BUGFIX] backend layout without colPos 0 (invalid value on cType field)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+3.4.0 => See https://forge.typo3.org/projects/extension-gridelements2/repository/show?rev=3-0
+
 3.3.4 => 2016-01-29 Jo Hasenau <info@cybercraft.de>
 	Fixed: Issue #72565 Make sure the move action was triggered by tt_content
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+3.3.4 => 2016-01-29 Jo Hasenau <info@cybercraft.de>
+	Fixed: Issue #72565 Make sure the move action was triggered by tt_content
+
 3.3.3 => 2015-12-16 Jo Hasenau <info@cybercraft.de>
 	Fixed: Issue #72147 Use correct shortcut identifier
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+3.3.3 => 2015-12-16 Jo Hasenau <info@cybercraft.de>
+	Fixed: Issue #72147 Use correct shortcut identifier
+
 3.3.2 => 2015-12-07 Jo Hasenau <info@cybercraft.de>
 	Fixed: Issue #71875 Respect deleted state within workspaces
 	Done: Issue #66782 Disable possibility to "move" children by changing their colPos

--- a/Classes/Backend/CmOptions.php
+++ b/Classes/Backend/CmOptions.php
@@ -3,6 +3,7 @@ namespace GridElementsTeam\Gridelements\Backend;
 
 use TYPO3\CMS\Backend\ClickMenu\ClickMenu;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Utility\DebugUtility;
 
 /**
  * Class/Function which
@@ -33,7 +34,7 @@ class CmOptions {
 		}
 
 		// add "paste reference after" if user is allowed to use CType shortcut
-		if ($GLOBALS['BE_USER']->checkAuthMode('tt_content', 'CType', 11, 'explicitAllow')) {
+		if ($GLOBALS['BE_USER']->checkAuthMode('tt_content', 'CType', 'shortcut', 'explicitAllow')) {
 			$parkItem = $menuItems['pasteafter'];
 			if ($parkItem) {
 				unset($menuItems['pasteafter']);

--- a/Classes/Backend/CmOptions.php
+++ b/Classes/Backend/CmOptions.php
@@ -34,7 +34,7 @@ class CmOptions {
 		}
 
 		// add "paste reference after" if user is allowed to use CType shortcut
-		if ($GLOBALS['BE_USER']->checkAuthMode('tt_content', 'CType', 'shortcut', 'explicitAllow')) {
+		if ($GLOBALS['BE_USER']->checkAuthMode('tt_content', 'CType', 'shortcut', $GLOBALS['TYPO3_CONF_VARS']['BE']['explicitADmode'])) {
 			$parkItem = $menuItems['pasteafter'];
 			if ($parkItem) {
 				unset($menuItems['pasteafter']);

--- a/Classes/Backend/ItemsProcFuncs/ColPosList.php
+++ b/Classes/Backend/ItemsProcFuncs/ColPosList.php
@@ -47,7 +47,7 @@ class ColPosList extends AbstractItemsProcFunc {
 		} else {
 			// negative uid_pid values indicate that the element has been inserted after an existing element
 			// so there is no pid to get the backendLayout for and we have to get that first
-			$existingElement = $GLOBALS['TYPO3_DB']->exec_SELECTgetSingleRow('pid, CType', 'tt_content', 'uid=' . -((int)$params['row']['pid']));
+			$existingElement = $GLOBALS['TYPO3_DB']->exec_SELECTgetSingleRow('pid, CType, tx_gridelements_container', 'tt_content', 'uid=' . -((int)$params['row']['pid']));
 			if ($existingElement['pid'] > 0) {
 				$params['items'] = $this->addColPosListLayoutItems($existingElement['pid'], $params['items'], $existingElement['CType'], $existingElement['tx_gridelements_container']);
 			}

--- a/Classes/DataHandler/MoveRecord.php
+++ b/Classes/DataHandler/MoveRecord.php
@@ -96,7 +96,7 @@ class MoveRecord extends AbstractDataHandler {
 	public function execute_moveRecord_firstElementPostProcess($table, $uid, $destPid, $moveRec, $updateFields, \TYPO3\CMS\Core\DataHandling\DataHandler &$parentObj) {
 		if ($table === 'tt_content') {
 			$cmd = GeneralUtility::_GET('cmd');
-			$commandUid = key($cmd['tt_content']);
+			$commandUid = is_array($cmd['tt_content']) ? key($cmd['tt_content']) : 0;
 			if($commandUid !== $uid) {
 				return;
 			}
@@ -153,7 +153,7 @@ class MoveRecord extends AbstractDataHandler {
 			$cmd = GeneralUtility::_GET('cmd');
 
 			$originalUid = (int)($movedRecord['_ORIG_uid'] ? $movedRecord['_ORIG_uid'] : $uid);
-			$commandUid = key($cmd['tt_content']);
+			$commandUid = is_array($cmd['tt_content']) ? key($cmd['tt_content']) : 0;
 			$placeholderUid = (int)($movedRecord['t3ver_move_id'] ? $movedRecord['t3ver_move_id'] : $uid);
 
 			if (strpos($cmd['tt_content'][$commandUid]['move'], 'x') !== FALSE) {

--- a/Classes/Hooks/DrawItem.php
+++ b/Classes/Hooks/DrawItem.php
@@ -351,7 +351,7 @@ class DrawItem implements PageLayoutViewDrawItemHookInterface {
 				<div class="t3-page-ce' . $statusHidden . '"><div class="t3-page-ce-dragitem">' . $this->renderSingleElementHTML($parentObject, $itemRow) . '</div></div>';
 					// New content element:
 					if ($parentObject->option_newWizard) {
-						$onClick = 'window.location.href=\'db_new_content_el.php?id=' . $itemRow['pid'] . '&sys_language_uid=' . $itemRow['sys_language_uid'] . '&colPos=' . $itemRow['colPos'] . '&uid_pid=' . -$itemRow['uid'] . '&returnUrl=' . rawurlencode(GeneralUtility::getIndpEnv('REQUEST_URI')) . '\';';
+						$onClick = 'window.location.href=\'db_new_content_el.php?id=' . $parentObject->id . '&sys_language_uid=' . $itemRow['sys_language_uid'] . '&colPos=' . $itemRow['colPos'] . '&uid_pid=' . -$itemRow['uid'] . '&returnUrl=' . rawurlencode(GeneralUtility::getIndpEnv('REQUEST_URI')) . '\';';
 					} else {
 						$params = '&edit[tt_content][' . -$itemRow['uid'] . ']=new';
 						$onClick = BackendUtility::editOnClick($params, $parentObject->backPath);

--- a/Classes/Hooks/DrawItem.php
+++ b/Classes/Hooks/DrawItem.php
@@ -283,8 +283,8 @@ class DrawItem implements PageLayoutViewDrawItemHookInterface {
 		$originalPidSelect = $parentObject->pidSelect;
 		$helper = Helper::getInstance();
 		$specificIds = $helper->getSpecificIds($row);
-
-		$parentObject->pidSelect = 'pid = ' . $row['pid'];
+        
+        $parentObject->pidSelect = 'pid = ' . $specificIds['pid'];
 
 		if (!$parentObject->tt_contentConfig['languageMode']) {
 			$showLanguage = ' AND (sys_language_uid = -1 OR sys_language_uid=' . $parentObject->tt_contentConfig['sys_language_uid'] . ')';
@@ -295,7 +295,7 @@ class DrawItem implements PageLayoutViewDrawItemHookInterface {
 		}
 
 		if ($helper->getBackendUser()->workspace > 0 && $row['t3ver_wsid'] > 0) {
-			$where = 'AND t3ver_wsid = ' . $row['t3ver_wsid'];
+			$where = ' AND t3ver_wsid = ' . $row['t3ver_wsid'];
 		}
 		$where .= ' AND colPos = -1 AND tx_gridelements_container IN (' . $row['uid'] . ',' . $specificIds['uid'] . ') AND tx_gridelements_columns=' . $colPos . $showHidden . $deleteClause . $showLanguage;
 

--- a/Classes/Hooks/PageRenderer.php
+++ b/Classes/Hooks/PageRenderer.php
@@ -180,7 +180,7 @@ class PageRenderer {
 						top.DDtoken = '" . $formprotection->generateToken('editRecord') . "';
 						top.DDpid = '" . (int)GeneralUtility::_GP('id') . "';
 						top.DDclipboardfilled = '" . ($clipBoardHasContent ? $clipBoardHasContent : 'false') . "';
-						top.pasteReferenceAllowed = '" . ($GLOBALS['BE_USER']->checkAuthMode('tt_content', 'CType', 'shortcut', 'explicitAllow') ? 'true' : 'false') . "';
+						top.pasteReferenceAllowed = '" . ($GLOBALS['BE_USER']->checkAuthMode('tt_content', 'CType', 'shortcut', $GLOBALS['TYPO3_CONF_VARS']['BE']['explicitADmode']) ? 'true' : 'false') . "';
 						top.newElementWizard = '" . ($modTSconfig['properties']['disableNewContentElementWizard'] ? 'false' : 'true') . "';
 						top.DDclipboardElId = '" . $intFirstCBEl . "';
 					" . // replace placeholder for detail info on draggables

--- a/Classes/Hooks/PageRenderer.php
+++ b/Classes/Hooks/PageRenderer.php
@@ -180,7 +180,7 @@ class PageRenderer {
 						top.DDtoken = '" . $formprotection->generateToken('editRecord') . "';
 						top.DDpid = '" . (int)GeneralUtility::_GP('id') . "';
 						top.DDclipboardfilled = '" . ($clipBoardHasContent ? $clipBoardHasContent : 'false') . "';
-						top.pasteReferenceAllowed = '" . ($GLOBALS['BE_USER']->checkAuthMode('tt_content', 'CType', 11, 'explicitAllow') ? 'true' : 'false') . "';
+						top.pasteReferenceAllowed = '" . ($GLOBALS['BE_USER']->checkAuthMode('tt_content', 'CType', 'shortcut', 'explicitAllow') ? 'true' : 'false') . "';
 						top.newElementWizard = '" . ($modTSconfig['properties']['disableNewContentElementWizard'] ? 'false' : 'true') . "';
 						top.DDclipboardElId = '" . $intFirstCBEl . "';
 					" . // replace placeholder for detail info on draggables

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -1,4 +1,5 @@
-lib.gridelements.defaultGridSetup { // stdWrap functions being applied to each element
+// stdWrap functions being applied to each element
+lib.gridelements.defaultGridSetup {
 	columns {
 		default {
 			renderObj = COA

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -16,7 +16,7 @@ $EM_CONF[$_EXTKEY] = array(
 It offers a lot of new features like advanced drag & drop or real references, that improve the usability of the page and list module to speed up the daily work with the backend.',
 	'category' => 'be',
 	'shy' => 0,
-	'version' => '3.3.3',
+	'version' => '3.3.4',
 	'dependencies' => 'cms',
 	'conflicts' => 'templavoila,jfmulticontent',
 	'priority' => 'bottom',

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -16,7 +16,7 @@ $EM_CONF[$_EXTKEY] = array(
 It offers a lot of new features like advanced drag & drop or real references, that improve the usability of the page and list module to speed up the daily work with the backend.',
 	'category' => 'be',
 	'shy' => 0,
-	'version' => '3.3.4',
+	'version' => '3.4.0',
 	'dependencies' => 'cms',
 	'conflicts' => 'templavoila,jfmulticontent',
 	'priority' => 'bottom',

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -16,7 +16,7 @@ $EM_CONF[$_EXTKEY] = array(
 It offers a lot of new features like advanced drag & drop or real references, that improve the usability of the page and list module to speed up the daily work with the backend.',
 	'category' => 'be',
 	'shy' => 0,
-	'version' => '3.3.2',
+	'version' => '3.3.3',
 	'dependencies' => 'cms',
 	'conflicts' => 'templavoila,jfmulticontent',
 	'priority' => 'bottom',


### PR DESCRIPTION
Bug : 
<img width="545" alt="capture d ecran 2017-07-25 a 17 57 49" src="https://user-images.githubusercontent.com/6927671/28581555-cdfd2048-7162-11e7-9e2c-d4845d2eca04.png">

When adding a content from list mode : 
<img width="276" alt="capture d ecran 2017-07-25 a 17 59 12" src="https://user-images.githubusercontent.com/6927671/28581656-16a111c4-7163-11e7-8b98-788eb6837b60.png">

When the backend layout havent colPos with the id "zero", when you add content from list mode, all cType are unset 