### PR TITLE
[BUGFIX] invalid value "text" with a backendlayout without colPos "zero"

### DIFF
--- a/Classes/Backend/ItemsProcFuncs/CTypeList.php
+++ b/Classes/Backend/ItemsProcFuncs/CTypeList.php
@@ -82,7 +82,7 @@ class CTypeList extends AbstractItemsProcFunc {
 		}
 		if (isset($backendLayout)) {
 			foreach ($items as $key => $item) {
-				if (!(GeneralUtility::inList($backendLayout['columns'][$column], $item[1]) || GeneralUtility::inList($backendLayout['columns'][$column], '*'))) {
+				if (!empty($backendLayout['columns'][$column]) && !(GeneralUtility::inList($backendLayout['columns'][$column], $item[1]) || GeneralUtility::inList($backendLayout['columns'][$column], '*'))) {
 					unset($items[$key]);
 				}
 			}


### PR DESCRIPTION
Bug (empty ctype)
<img width="545" alt="capture d ecran 2017-07-25 a 17 57 49" src="https://user-images.githubusercontent.com/6927671/28582304-34a620ea-7165-11e7-96f5-32449d37f62c.png">

from list mode insert 
<img width="276" alt="capture d ecran 2017-07-25 a 17 59 12" src="https://user-images.githubusercontent.com/6927671/28582335-43c5f104-7165-11e7-8b87-10b9dc8c2b5c.png">

dont unset ctypes if backend layout havent column with colPos "zero"