### PR TITLE
[Fix] Column width not responding to colspan

### DIFF
--- a/Resources/Public/Backend/Css/Skin/t3skin_override.css
+++ b/Resources/Public/Backend/Css/Skin/t3skin_override.css
@@ -24,7 +24,6 @@
 
 .t3-page-columns {
 	border-spacing: 10px !important;
-	width: auto;
 	min-width: 100%;
 }
 


### PR DESCRIPTION
When using GridElements you couldn't get unequal length columns in the backend using colspan = 2 or higher.
This fix removes the column width override so you can use backendlayouts with colspan and gridelements together.