### PR TITLE
[TASK] make rendered view of children iterable in fluid

### DIFF
--- a/Classes/Plugin/Gridelements.php
+++ b/Classes/Plugin/Gridelements.php
@@ -267,13 +267,16 @@ class Gridelements extends ContentObjectRenderer
         // each of the children will now be rendered separately and the output will be added to it's particular column
         $rawColumns = array();
         if (!empty($this->cObj->data['tx_gridelements_view_children'])) {
+            $index = 0;
             foreach ($this->cObj->data['tx_gridelements_view_children'] as $child) {
                 $rawColumns[$child['tx_gridelements_columns']][] = $child;
                 $renderedChild = $child;
                 $this->renderChildIntoParentColumn($columns, $renderedChild, $parentGridData, $parentRecordNumbers,
                     $typoScriptSetup);
                 $currentParentGrid['data']['tx_gridelements_view_child_' . $child['uid']] = $renderedChild;
+                $currentParentGrid['data']['tx_gridelements_view_children'][$index]['tx_gridelements_view'] = $renderedChild;
                 unset($renderedChild);
+                ++$index;
             }
             $currentParentGrid['data']['tx_gridelements_view_raw_columns'] = $rawColumns;
         }


### PR DESCRIPTION
The available data structure `tx_gridelements_view_child_' . $child['uid']]` belongs to the parent element and can not be iterated thru in fluid. 
So I added the rendered view of a children to the tx_gridelements_view_children dataset.
This makes it possible to iterate thru that datastructure in fluid like this:
```
<f:for each="{data.tx_gridelements_view_children}" as="item">
	<h3>{item.header}</h3>
	<div id="c{item.uid}">
		<f:format.raw>{item.tx_gridelements_view}</f:format.raw>
	</div>
</f:for>
```
The new added element `tx_gridelements_view`allows that.