### PR TITLE
[BUGFIX] CType detection failed

### DIFF
--- a/Classes/Backend/ItemsProcFuncs/CTypeList.php
+++ b/Classes/Backend/ItemsProcFuncs/CTypeList.php
@@ -120,9 +120,7 @@ class CTypeList extends AbstractItemsProcFunc
     public function init($pageId = 0)
     {
         parent::init();
-        if (!$this->layoutSetup) {
-            $this->injectLayoutSetup(GeneralUtility::makeInstance(LayoutSetup::class)->init($pageId));
-        }
+        $this->injectLayoutSetup(GeneralUtility::makeInstance(LayoutSetup::class)->init($pageId));
     }
 
     /**


### PR DESCRIPTION
The CType detection failed when LayoutSetup is initialised with pageId = 0.

This problem appears, when adding a new child element, the first works, the second will cause the ParentId to be negativ id, therefore the initialise is done with pageId 0 and will not detect the possible CTypes (dropdown field is empty, no selections possible)