### PR TITLE
Fix Scan Tool Errors

### DIFF
--- a/Classes/Hooks/DrawItem.php
+++ b/Classes/Hooks/DrawItem.php
@@ -29,6 +29,7 @@ use TYPO3\CMS\Backend\View\PageLayoutView;
 use TYPO3\CMS\Backend\View\PageLayoutViewDrawFooterHookInterface;
 use TYPO3\CMS\Backend\View\PageLayoutViewDrawItemHookInterface;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
@@ -109,7 +110,8 @@ class DrawItem implements PageLayoutViewDrawItemHookInterface, SingletonInterfac
 
     public function __construct()
     {
-        $this->extentensionConfiguration = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['gridelements']);
+        $extConf = GeneralUtility::makeInstance(ExtensionConfiguration::class);
+        $this->extentensionConfiguration = $extConf->get('gridelements');
         $this->setLanguageService($GLOBALS['LANG']);
         $this->helper = Helper::getInstance();
         $this->iconFactory = GeneralUtility::makeInstance(IconFactory::class);

--- a/Classes/Hooks/PageRenderer.php
+++ b/Classes/Hooks/PageRenderer.php
@@ -30,7 +30,7 @@ use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Recordlist\RecordList;
+use TYPO3\CMS\Recordlist\Controller\RecordListController;
 
 /**
  * Class/Function which adds the necessary ExtJS and pure JS stuff for the grid elements.
@@ -57,8 +57,8 @@ class PageRenderer implements SingletonInterface
      */
     public function addJSCSS(array $parameters, \TYPO3\CMS\Core\Page\PageRenderer $pageRenderer)
     {
-        if (!empty($GLOBALS['SOBE']) && (get_class($GLOBALS['SOBE']) === RecordList::class || is_subclass_of($GLOBALS['SOBE'],
-                    RecordList::class))) {
+        if (!empty($GLOBALS['SOBE']) && (get_class($GLOBALS['SOBE']) === RecordListController::class || is_subclass_of($GLOBALS['SOBE'],
+                    RecordListController::class))) {
             $pageRenderer->loadRequireJsModule('TYPO3/CMS/Gridelements/GridElementsOnReady');
             return;
         }

--- a/Classes/Hooks/PageRenderer.php
+++ b/Classes/Hooks/PageRenderer.php
@@ -76,7 +76,7 @@ class PageRenderer implements SingletonInterface
             $clipObj->lockToNormal();
             $clipBoard = $clipObj->clipData['normal'];
             if (!$pageRenderer->getCharSet()) {
-                $pageRenderer->setCharSet($GLOBALS['LANG']->charSet ? $GLOBALS['LANG']->charSet : 'utf-8');
+                $pageRenderer->setCharSet('utf-8');
             }
 
             // pull locallang_db.xml to JS side - only the tx_gridelements_js-prefixed keys

--- a/Classes/Xclass/DatabaseRecordList.php
+++ b/Classes/Xclass/DatabaseRecordList.php
@@ -712,7 +712,7 @@ class DatabaseRecordList extends \TYPO3\CMS\Recordlist\RecordList\DatabaseRecord
         $this->selFieldList = $selFieldList;
         if (is_array($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/class.db_list_extra.inc']['getTable'])) {
             foreach ($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/class.db_list_extra.inc']['getTable'] as $classData) {
-                $hookObject = GeneralUtility::getUserObj($classData);
+                $hookObject = GeneralUtility::makeInstance($classData);
                 if (!$hookObject instanceof RecordListGetTableHookInterface) {
                     throw new \UnexpectedValueException($classData . ' must implement interface ' . RecordListGetTableHookInterface::class,
                         1195114460);
@@ -1279,7 +1279,7 @@ class DatabaseRecordList extends \TYPO3\CMS\Recordlist\RecordList\DatabaseRecord
          */
         if (is_array($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/class.db_list_extra.inc']['actions'])) {
             foreach ($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/class.db_list_extra.inc']['actions'] as $classData) {
-                $hookObject = GeneralUtility::getUserObj($classData);
+                $hookObject = GeneralUtility::makeInstance($classData);
                 if (is_object($hookObject) && method_exists($hookObject, 'checkChildren')) {
                     $hookObject->checkChildren($table, $row, $level, $theData, $this);
                 }
@@ -1731,7 +1731,7 @@ class DatabaseRecordList extends \TYPO3\CMS\Recordlist\RecordList\DatabaseRecord
                 }
             }
             foreach ($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/class.db_list_extra.inc']['actions'] as $classData) {
-                $hookObject = GeneralUtility::getUserObj($classData);
+                $hookObject = GeneralUtility::makeInstance($classData);
                 if (!$hookObject instanceof RecordListHookInterface) {
                     throw new \UnexpectedValueException($classData . ' must implement interface ' . RecordListHookInterface::class,
                         1195567840);
@@ -2033,7 +2033,7 @@ class DatabaseRecordList extends \TYPO3\CMS\Recordlist\RecordList\DatabaseRecord
          */
         if (is_array($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/class.db_list_extra.inc']['actions'])) {
             foreach ($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/class.db_list_extra.inc']['actions'] as $classData) {
-                $hookObject = GeneralUtility::getUserObj($classData);
+                $hookObject = GeneralUtility::makeInstance($classData);
                 if (!$hookObject instanceof RecordListHookInterface) {
                     throw new \UnexpectedValueException($classData . ' must implement interface ' . RecordListHookInterface::class,
                         1195567845);
@@ -2150,7 +2150,7 @@ class DatabaseRecordList extends \TYPO3\CMS\Recordlist\RecordList\DatabaseRecord
                  */
                 if (is_array($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/class.db_list_extra.inc']['actions'])) {
                     foreach ($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/class.db_list_extra.inc']['actions'] as $classData) {
-                        $hookObject = GeneralUtility::getUserObj($classData);
+                        $hookObject = GeneralUtility::makeInstance($classData);
                         if (is_object($hookObject) && method_exists($hookObject, 'contentCollapseIcon')) {
                             $hookObject->contentCollapseIcon($data, $sortField, $level, $contentCollapseIcon, $this);
                         }
@@ -2466,7 +2466,7 @@ class DatabaseRecordList extends \TYPO3\CMS\Recordlist\RecordList\DatabaseRecord
                      */
                     if (is_array($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/class.db_list_extra.inc']['actions'])) {
                         foreach ($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/class.db_list_extra.inc']['actions'] as $classData) {
-                            $hookObject = GeneralUtility::getUserObj($classData);
+                            $hookObject = GeneralUtility::makeInstance($classData);
                             if (!$hookObject instanceof RecordListHookInterface) {
                                 throw new \UnexpectedValueException($classData . ' must implement interface ' . RecordListHookInterface::class,
                                     1195567850);
@@ -2628,7 +2628,7 @@ class DatabaseRecordList extends \TYPO3\CMS\Recordlist\RecordList\DatabaseRecord
          */
         if (is_array($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/class.db_list_extra.inc']['actions'])) {
             foreach ($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/class.db_list_extra.inc']['actions'] as $classData) {
-                $hookObject = GeneralUtility::getUserObj($classData);
+                $hookObject = GeneralUtility::makeInstance($classData);
                 if (!$hookObject instanceof RecordListHookInterface) {
                     throw new \UnexpectedValueException($classData . ' must implement interface ' . RecordListHookInterface::class,
                         1195567855);

--- a/Classes/Xclass/DatabaseRecordList.php
+++ b/Classes/Xclass/DatabaseRecordList.php
@@ -17,6 +17,7 @@ namespace GridElementsTeam\Gridelements\Xclass;
 
 use TYPO3\CMS\Backend\Module\BaseScriptClass;
 use TYPO3\CMS\Backend\RecordList\RecordListGetTableHookInterface;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Backend\Template\Components\ButtonBar;
 use TYPO3\CMS\Backend\Template\DocumentTemplate;
 use TYPO3\CMS\Backend\Template\ModuleTemplate;
@@ -303,8 +304,9 @@ class DatabaseRecordList extends \TYPO3\CMS\Recordlist\RecordList\DatabaseRecord
             }
             // New record on pages that are not locked by editlock
             if (!$module->modTSconfig['properties']['noCreateRecordsLink'] && $this->editLockPermissions()) {
-                $onClick = htmlspecialchars('return jumpExt(' . GeneralUtility::quoteJSvalue(BackendUtility::getModuleUrl('db_new',
-                        ['id' => $this->id])) . ');');
+                $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
+                $onClick = htmlspecialchars('return jumpExt(' . GeneralUtility::quoteJSvalue(
+                        $uriBuilder->buildUriFromRoute('db_new', ['id' => $this->id])) . ');');
                 $buttons['new_record'] = '<a href="#" onclick="' . $onClick . '" title="'
                     . htmlspecialchars($lang->getLL('newRecordGeneral')) . '">'
                     . $this->iconFactory->getIcon('actions-add', Icon::SIZE_SMALL)->render() . '</a>';
@@ -350,7 +352,8 @@ class DatabaseRecordList extends \TYPO3\CMS\Recordlist\RecordList\DatabaseRecord
                     . $this->iconFactory->getIcon('actions-document-export-csv', Icon::SIZE_SMALL)->render() . '</a>';
                 // Export
                 if (ExtensionManagementUtility::isLoaded('impexp')) {
-                    $url = BackendUtility::getModuleUrl('xMOD_tximpexp', ['tx_impexp[action]' => 'export']);
+                    $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
+                    $url = $uriBuilder->buildUriFromRoute('xMOD_tximpexp', ['tx_impexp[action]' => 'export']);
                     $buttons['export'] = '<a href="' . htmlspecialchars($url . '&tx_impexp[list][]='
                             . rawurlencode($this->table . ':' . $this->id)) . '" title="'
                         . htmlspecialchars($lang->sL('LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:rm.export')) . '">'
@@ -449,8 +452,9 @@ class DatabaseRecordList extends \TYPO3\CMS\Recordlist\RecordList\DatabaseRecord
             }
             // New record on pages that are not locked by editlock
             if (!$module->modTSconfig['properties']['noCreateRecordsLink'] && $this->editLockPermissions()) {
-                $onClick = 'return jumpExt(' . GeneralUtility::quoteJSvalue(BackendUtility::getModuleUrl('db_new',
-                        ['id' => $this->id])) . ');';
+                $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
+                $onClick = 'return jumpExt(' . GeneralUtility::quoteJSvalue(
+                        $uriBuilder->buildUriFromRoute('db_new', ['id' => $this->id])) . ');';
                 $newRecordButton = $buttonBar->makeLinkButton()
                     ->setHref('#')
                     ->setOnClick($onClick)
@@ -516,7 +520,8 @@ class DatabaseRecordList extends \TYPO3\CMS\Recordlist\RecordList\DatabaseRecord
                 $buttonBar->addButton($csvButton, ButtonBar::BUTTON_POSITION_LEFT, 40);
                 // Export
                 if (ExtensionManagementUtility::isLoaded('impexp')) {
-                    $url = BackendUtility::getModuleUrl('xMOD_tximpexp', ['tx_impexp[action]' => 'export']);
+                    $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
+                    $url = $uriBuilder->buildUriFromRoute('xMOD_tximpexp', ['tx_impexp[action]' => 'export']);
                     $exportButton = $buttonBar->makeLinkButton()
                         ->setHref($url . '&tx_impexp[list][]=' . rawurlencode($this->table . ':' . $this->id))
                         ->setTitle($lang->sL('LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:rm.export'))
@@ -1513,7 +1518,9 @@ class DatabaseRecordList extends \TYPO3\CMS\Recordlist\RecordList\DatabaseRecord
         $this->addActionToCellGroup($cells, $viewBigAction, 'viewBig');
         // "Move" wizard link for pages/tt_content elements:
         if ($permsEdit && ($table === 'tt_content' || $table === 'pages')) {
-            $onClick = 'return jumpExt(' . GeneralUtility::quoteJSvalue(BackendUtility::getModuleUrl('move_element') . '&table=' . $table . '&uid=' . $row['uid']) . ');';
+            $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
+            $onClick = 'return jumpExt(' . GeneralUtility::quoteJSvalue(
+                $uriBuilder->buildUriFromRoute('move_element' ) . '&table=' . $table . '&uid=' . $row['uid']) . ');';
             $linkTitleLL = htmlspecialchars($this->getLanguageService()->getLL('move_' . ($table === 'tt_content' ? 'record' : 'page')));
             $icon = ($table === 'pages' ? $this->iconFactory->getIcon('actions-page-move',
                 Icon::SIZE_SMALL) : $this->iconFactory->getIcon('actions-document-move', Icon::SIZE_SMALL));
@@ -1523,7 +1530,8 @@ class DatabaseRecordList extends \TYPO3\CMS\Recordlist\RecordList\DatabaseRecord
         // If the table is NOT a read-only table, then show these links:
         if ($this->isEditable($table)) {
             // "Revert" link (history/undo)
-            $moduleUrl = BackendUtility::getModuleUrl('record_history', ['element' => $table . ':' . $row['uid']]);
+            $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
+            $moduleUrl = $uriBuilder->buildUriFromRoute('record_history', ['element' => $table . ':' . $row['uid']]);
             $onClick = 'return jumpExt(' . GeneralUtility::quoteJSvalue($moduleUrl) . ',\'#latest\');';
             $historyAction = '<a class="btn btn-default" href="#" onclick="' . htmlspecialchars($onClick) . '" title="'
                 . htmlspecialchars($this->getLanguageService()->getLL('history')) . '">'
@@ -1535,7 +1543,8 @@ class DatabaseRecordList extends \TYPO3\CMS\Recordlist\RecordList\DatabaseRecord
                     $this->getBackendUserAuthentication()->workspace, false, $row);
                 // If table can be versionized.
                 if (is_array($vers)) {
-                    $href = BackendUtility::getModuleUrl('web_txversionM1', [
+                    $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
+                    $href = $uriBuilder->buildUriFromRoute('web_txversionM1', [
                         'table' => $table,
                         'uid'   => $row['uid'],
                     ]);
@@ -1548,7 +1557,8 @@ class DatabaseRecordList extends \TYPO3\CMS\Recordlist\RecordList\DatabaseRecord
             // "Edit Perms" link:
             if ($table === 'pages' && $this->getBackendUserAuthentication()->check('modules',
                     'system_BeuserTxPermission') && ExtensionManagementUtility::isLoaded('beuser')) {
-                $href = BackendUtility::getModuleUrl('system_BeuserTxPermission') . '&id=' . $row['uid'] . '&returnId=' . $row['uid'] . '&tx_beuser_system_beusertxpermission[action]=edit';
+                $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
+                $href = $uriBuilder->buildUriFromRoute('system_BeuserTxPermission') . '&id=' . $row['uid'] . '&returnId=' . $row['uid'] . '&tx_beuser_system_beusertxpermission[action]=edit';
                 $permsAction = '<a class="btn btn-default" href="' . htmlspecialchars($href) . '" title="'
                     . htmlspecialchars($this->getLanguageService()->getLL('permissions')) . '">'
                     . $this->iconFactory->getIcon('actions-lock', Icon::SIZE_SMALL)->render() . '</a>';
@@ -2509,7 +2519,8 @@ class DatabaseRecordList extends \TYPO3\CMS\Recordlist\RecordList\DatabaseRecord
                                 $newContentElementWizard = isset($tmpTSc['properties']['newContentElementWizard.']['override'])
                                     ? $tmpTSc['properties']['newContentElementWizard.']['override']
                                     : 'new_content_element';
-                                $newContentWizScriptPath = BackendUtility::getModuleUrl($newContentElementWizard,
+                                $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
+                                $newContentWizScriptPath = $uriBuilder->buildUriFromRoute($newContentElementWizard,
                                     ['id' => $this->id]);
 
                                 $onClick = 'return jumpExt(' . GeneralUtility::quoteJSvalue($newContentWizScriptPath) . ');';
@@ -2521,7 +2532,8 @@ class DatabaseRecordList extends \TYPO3\CMS\Recordlist\RecordList\DatabaseRecord
                                     'pagesOnly' => 1,
                                     'returnUrl' => GeneralUtility::getIndpEnv('REQUEST_URI'),
                                 ];
-                                $href = BackendUtility::getModuleUrl('db_new', $parameters);
+                                $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
+                                $href = $uriBuilder->buildUriFromRoute('db_new', $parameters);
                                 $icon = '<a class="btn btn-default" href="' . htmlspecialchars($href) . '" title="' . htmlspecialchars($lang->getLL('new')) . '">'
                                     . $spriteIcon->render() . '</a>';
                             } else {
@@ -2760,8 +2772,9 @@ class DatabaseRecordList extends \TYPO3\CMS\Recordlist\RecordList\DatabaseRecord
     public function pasteUrl($table, $uid, $setRedirect = true, array $update = null)
     {
         $formProtection = FormProtectionFactory::get();
-        return ($table === '_FILE' ? BackendUtility::getModuleUrl('tce_file',
-                []) : BackendUtility::getModuleUrl('tce_db', []))
+        $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
+        return ($table === '_FILE' ? $uriBuilder->buildUriFromRoute('tce_file', [])
+                : $uriBuilder->buildUriFromRoute('tce_db', []))
             . ($setRedirect ? '&redirect=' . rawurlencode(GeneralUtility::linkThisScript(['CB' => ''])) : '')
             . '&vC=' . $this->getBackendUserAuthentication()->veriCode() . '&prErr=1&uPT=1' . '&CB[paste]='
             . rawurlencode($table . '|' . $uid) . '&CB[pad]=' . $this->clipObj->current

--- a/Classes/Xclass/DatabaseRecordList.php
+++ b/Classes/Xclass/DatabaseRecordList.php
@@ -2784,7 +2784,7 @@ class DatabaseRecordList extends \TYPO3\CMS\Recordlist\RecordList\DatabaseRecord
         return ($table === '_FILE' ? $uriBuilder->buildUriFromRoute('tce_file', [])
                 : $uriBuilder->buildUriFromRoute('tce_db', []))
             . ($setRedirect ? '&redirect=' . rawurlencode(GeneralUtility::linkThisScript(['CB' => ''])) : '')
-            . '&vC=' . $this->getBackendUserAuthentication()->veriCode() . '&prErr=1&uPT=1' . '&CB[paste]='
+            . '&prErr=1&uPT=1' . '&CB[paste]='
             . rawurlencode($table . '|' . $uid) . '&CB[pad]=' . $this->clipObj->current
             . (is_array($update) ? GeneralUtility::implodeArrayForUrl('CB[update]', $update) : '')
             . '&formToken=' . $formProtection->generateToken('tceAction');

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "romdum/gridelements",
+  "name": "gridelementsteam/gridelements",
   "description": "This extension integrates the grid layout concept also to regular content elements - the grid elements. It offers a lot of new features like advanced drag & drop or real references, that improve the usability of the page and list module to speed up the daily work with the backend.",
   "type": "typo3-cms-extension",
   "version": "9.0.0-dev",
@@ -12,10 +12,10 @@
     "issues": "https://forge.typo3.org/projects/extension-gridelements2/issues"
   },
   "require": {
-    "typo3/cms-core": "^9.5",
-    "typo3/cms-backend": "^9.5",
-    "typo3/cms-recordlist": "^9.5",
-    "typo3/cms-frontend": "^9.5"
+    "typo3/cms-core": "^9.5 || dev-master",
+    "typo3/cms-backend": "^9.5 || dev-master",
+    "typo3/cms-recordlist": "^9.5 || dev-master",
+    "typo3/cms-frontend": "^9.5 || dev-master"
   },
   "conflict": {
     "templavoila": "*",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "gridelementsteam/gridelements",
+  "name": "romdum/gridelements",
   "description": "This extension integrates the grid layout concept also to regular content elements - the grid elements. It offers a lot of new features like advanced drag & drop or real references, that improve the usability of the page and list module to speed up the daily work with the backend.",
   "type": "typo3-cms-extension",
   "version": "9.0.0-dev",
@@ -12,10 +12,10 @@
     "issues": "https://forge.typo3.org/projects/extension-gridelements2/issues"
   },
   "require": {
-    "typo3/cms-core": "^9.3 || dev-master",
-    "typo3/cms-backend": "^9.3 || dev-master",
-    "typo3/cms-recordlist": "^9.3 || dev-master",
-    "typo3/cms-frontend": "^9.3 || dev-master"
+    "typo3/cms-core": "^9.5 || dev-master",
+    "typo3/cms-backend": "^9.5 || dev-master",
+    "typo3/cms-recordlist": "^9.5 || dev-master",
+    "typo3/cms-frontend": "^9.5 || dev-master"
   },
   "conflict": {
     "templavoila": "*",

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
     "issues": "https://forge.typo3.org/projects/extension-gridelements2/issues"
   },
   "require": {
-    "typo3/cms-core": "^9.5 || dev-master",
-    "typo3/cms-backend": "^9.5 || dev-master",
-    "typo3/cms-recordlist": "^9.5 || dev-master",
-    "typo3/cms-frontend": "^9.5 || dev-master"
+    "typo3/cms-core": "^9.5",
+    "typo3/cms-backend": "^9.5",
+    "typo3/cms-recordlist": "^9.5",
+    "typo3/cms-frontend": "^9.5"
   },
   "conflict": {
     "templavoila": "*",

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -24,7 +24,8 @@ if (TYPO3_MODE === 'BE') {
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][] = \GridElementsTeam\Gridelements\Hooks\DataHandler::class;
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['moveRecordClass'][] = \GridElementsTeam\Gridelements\Hooks\DataHandler::class;
 
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_befunc.php']['getFlexFormDSClass'][] = \GridElementsTeam\Gridelements\Hooks\BackendUtilityGridelements::class;
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][\TYPO3\CMS\Core\Configuration\FlexForm\FlexFormTools::class]['flexParsing'][] = \GridElementsTeam\Gridelements\Hooks\BackendUtilityGridelements::class;
+    // $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_befunc.php']['getFlexFormDSClass'][] = \GridElementsTeam\Gridelements\Hooks\BackendUtilityGridelements::class;
 
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tx_templavoila_api']['apiIsRunningTCEmain'] = true;
 


### PR DESCRIPTION
Extension should now work with Typo3 V9.