### PR TITLE
Do not redefine colPos field in tt_content table

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -40,7 +40,6 @@ CREATE TABLE tx_gridelements_backend_layout (
 # Table structure for table 'tt_content'
 #
 CREATE TABLE tt_content (
-	colPos smallint(6) DEFAULT '0' NOT NULL,
 	layout varchar(255) DEFAULT '' NOT NULL,
 	backupColPos smallint(6) DEFAULT '-2' NOT NULL,
 	tx_gridelements_backend_layout varchar(255) DEFAULT '' NOT NULL,


### PR DESCRIPTION
It's already defined in core so we can remove it here. Also making it smaller as in the core (smallint vs int) is not good.

Background: https://github.com/FluidTYPO3/flux/issues/1676#issuecomment-486149451